### PR TITLE
Add langPatch test for changed comment handling

### DIFF
--- a/src/utils/__tests__/langPatch.test.ts
+++ b/src/utils/__tests__/langPatch.test.ts
@@ -159,4 +159,37 @@ duplicatedKey=Baz`,
       expect(patchLang({source, target, duplicatedKey: strategy})).toBe(expected[strategy]),
     );
   });
+
+  describe("avoids overriding updated comments while replacing values", () => {
+    const oldSource = `# Old heading
+foo=Foo
+foo=Bar`;
+
+    const source = `# Updated heading
+foo=Foo
+foo=Bar`;
+
+    const target = `# 日本語の見出し
+foo=Hoge
+foo=Piyo`;
+
+    const expected = {
+      ignore: `# Updated heading
+foo=Foo
+foo=Bar`,
+      first: `# Updated heading
+foo=Hoge
+foo=Hoge`,
+      last: `# Updated heading
+foo=Piyo
+foo=Piyo`,
+      pop: `# Updated heading
+foo=Hoge
+foo=Piyo`,
+    } as const;
+
+    test.each(duplicatedKeyStrategies)("(duplicatedKey=%s)", strategy =>
+      expect(patchLang({oldSource, source, target, duplicatedKey: strategy})).toBe(expected[strategy]),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add coverage for COMMENT_KEY changes to ensure updated comments are preserved when patching language files
- document outputs for each duplicatedKey strategy while confirming value replacements

## Testing
- pnpm test langPatch

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938ffa2f59c8321bba183b001040d25)